### PR TITLE
Fix integer parameter placeholder: undefined offset

### DIFF
--- a/src/SqlProcessor.php
+++ b/src/SqlProcessor.php
@@ -221,9 +221,11 @@ class SqlProcessor
 						return $this->processArray("any[]", $value);
 
 					case 'i[]':
-						$i = count($value);
-						while ($i-- && is_int($value[$i]));
-						if ($i >= 0) break; // fallback to processArray
+						$nonInt = count($value);
+						foreach ($value as $v) {
+							if (is_int($v)) $nonInt--;
+						}
+						if ($nonInt > 0) break; // fallback to processArray 
 						return '(' . implode(', ', $value) . ')';
 
 					case 's[]':

--- a/tests/cases/unit/SqlProcessorTest.array.phpt
+++ b/tests/cases/unit/SqlProcessorTest.array.phpt
@@ -32,6 +32,11 @@ class SqlProcessorArrayTest extends TestCase
 		);
 
 		Assert::same(
+			'SELECT FROM test WHERE id IN (1, 2, 3)',
+			$this->convert('SELECT FROM test WHERE id IN %i[]', ['foo' => 1, 12 => 2, 0 => 3])
+		);
+
+		Assert::same(
 			'SELECT FROM test WHERE id IN ()',
 			$this->convert('SELECT FROM test WHERE id IN %i[]', [])
 		);


### PR DESCRIPTION
Failed on `%i[]` with non-sequential offsets.