### PR TITLE
pg driver: fixed %dt with interval

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"php": ">=5.4"
 	},
 	"require-dev": {
-		"nette/tester": "~1.4",
+		"nette/tester": "~1.4 != 1.6.1",
 		"mockery/mockery": "~0.9",
 		"tracy/tracy": "~2.3",
 		"nette/di": "~2.3"

--- a/src/Drivers/Pgsql/PgsqlDriver.php
+++ b/src/Drivers/Pgsql/PgsqlDriver.php
@@ -227,7 +227,7 @@ class PgsqlDriver implements IDriver
 						$value->setTimezone($this->connectionTz);
 					}
 				}
-				return "'" . $value->format('Y-m-d H:i:s') . "'";
+				return "'" . $value->format('Y-m-d H:i:s') . "'::timestamptz";
 
 			case self::TYPE_DATETIME_SIMPLE:
 				if ($value->getTimezone()->getName() !== $this->simpleStorageTz->getName()) {
@@ -238,7 +238,7 @@ class PgsqlDriver implements IDriver
 						$value->setTimezone($this->simpleStorageTz);
 					}
 				}
-				return "'" . $value->format('Y-m-d H:i:s') . "'";
+				return "'" . $value->format('Y-m-d H:i:s') . "'::timestamp";
 
 			case self::TYPE_DATE_INTERVAL:
 				return $value->format('P%yY%mM%dDT%hH%iM%sS');

--- a/tests/cases/integration/datetime.pgsql.phpt
+++ b/tests/cases/integration/datetime.pgsql.phpt
@@ -174,6 +174,19 @@ class DateTimePostgreTest extends IntegrationTestCase
 		Assert::same('2015-01-01T13:00:00+02:00', $row->b->format('c'));
 	}
 
+
+	public function testUsageWithInterval()
+	{
+		$connection = $this->createConnection();
+
+		Assert::noError(function() use ($connection) {
+			$connection->query(
+				'SELECT Now() <= %dt + (INTERVAL \'2 DAYS\')',
+				new DateTime()
+			);
+		});
+	}
+
 }
 
 


### PR DESCRIPTION
> Nextras\Dbal\QueryException: ERROR:  invalid input syntax for type interval: "2015-10-28 11:22:42"
> `LINE 1: SELECT Now() <= '2015-10-28 11:22:42' + (INTERVAL '2 DAYS')`