### PR TITLE
SqlProcessor::processMultiValues() - fixed $value usage

### DIFF
--- a/src/SqlProcessor.php
+++ b/src/SqlProcessor.php
@@ -379,12 +379,15 @@ class SqlProcessor
 	{
 		if (empty($value)) {
 			throw new InvalidArgumentException('Modifier %values[] must contain at least one array element.');
-		} elseif (empty($value[0])) {
+		}
+
+		$firstSubValue = reset($value);
+		if (empty($firstSubValue)) {
 			return 'VALUES ' . str_repeat('(DEFAULT), ', count($value) - 1) . '(DEFAULT)';
 		}
 
 		$keys = $values = [];
-		foreach (array_keys($value[0]) as $key) {
+		foreach (array_keys($firstSubValue) as $key) {
 			$keys[] = $this->identifiers->{explode('%', $key, 2)[0]};
 		}
 		foreach ($value as $subValue) {

--- a/tests/cases/unit/SqlProcessorTest.values.phpt
+++ b/tests/cases/unit/SqlProcessorTest.values.phpt
@@ -60,7 +60,7 @@ class SqlProcessorValuesTest extends TestCase
 		Assert::same(
 			"INSERT INTO test (id, title, foo) VALUES (1, '\\'foo\\'', 2), (2, '\\'foo2\\'', 3)",
 			$this->convert('INSERT INTO test %values[]', [
-				[
+				1 => [
 					'id%i' => 1,
 					'title%s' => "'foo'",
 					'foo' => 2,


### PR DESCRIPTION
I ran into a problem with this code:

``` php
public function createNonExisting(array $labels)
{
    if (empty($labels)) {
        return;
    }
    $values = array_map(function ($label) {
        return ['label' => $label];
    }, array_filter($labels));
    $this->connection->query('INSERT INTO [tags] %values[] ON CONFLICT DO NOTHING', $values);
}
```

If the first element of `$labels` is an empty string, it will get filtered out and the array will then be starting with key `1` instead of `0`. With such array given as `$value` parameter to `SqlProcessor::processMultiValues()` an incorrect string `VALUES (DEFAULT), (DEFAULT), ...` will be returned.

This pull request fixes the problem.
