### PR TITLE
MysqliDriver: fix flipped minutes / seconds and missing apostrophe

### DIFF
--- a/src/Drivers/Mysqli/MysqliDriver.php
+++ b/src/Drivers/Mysqli/MysqliDriver.php
@@ -274,7 +274,7 @@ class MysqliDriver implements IDriver
 			// see https://dev.mysql.com/doc/refman/5.0/en/time.html
 			throw new InvalidArgumentException('Mysql cannot store interval bigger than 839h:59m:59s.');
 		}
-		return $value->format("%r{$totalHours}:%S:%I");
+		return "'" . $value->format("%r{$totalHours}:%I:%S") . "'";
 	}
 
 

--- a/tests/cases/integration/driver.mysql.phpt
+++ b/tests/cases/integration/driver.mysql.phpt
@@ -33,16 +33,16 @@ class DriverMysqlTest extends IntegrationTestCase
 	{
 		$driver = $this->connection->getDriver();
 
-		$interval1 = (new DateTime('2015-01-03 12:01:01'))->diff(new DateTime('2015-01-01 09:00:00'));
-		$interval2 = (new DateTime('2015-01-01 09:00:00'))->diff(new DateTime('2015-01-03 12:01:01'));
+		$interval1 = (new DateTime('2015-01-03 12:01:01'))->diff(new DateTime('2015-01-01 09:00:01'));
+		$interval2 = (new DateTime('2015-01-01 09:00:00'))->diff(new DateTime('2015-01-03 12:01:05'));
 
-		Assert::same('-51:01:01', $driver->convertDateIntervalToSql($interval1));
-		Assert::same('51:01:01', $driver->convertDateIntervalToSql($interval2));
+		Assert::same("-51:01:00", trim($driver->convertDateIntervalToSql($interval1), "'"));
+		Assert::same("51:01:05", trim($driver->convertDateIntervalToSql($interval2), "'"));
 
 		Assert::throws(function() use ($driver) {
 			$interval = (new DateTime('2015-02-05 09:59:59'))->diff(new DateTime('2015-01-01 09:00:00'));
 			$driver->convertDateIntervalToSql($interval);
-		}, InvalidArgumentException::class);
+		}, InvalidArgumentException::class, 'Mysql cannot store interval bigger than 839h:59m:59s.');
 	}
 
 


### PR DESCRIPTION
Origin state:

`return $value->format("%r{$totalHours}:%S:%I");`

Flip seconds / minutes:

`return $value->format("%r{$totalHours}:%I:%S");`

Missing apostrophe (mysql throws exception):

`return "'" . $value->format("%r{$totalHours}:%I:%S") . "'";`