### PR TITLE
Fix setting of transaction isolation levels

### DIFF
--- a/src/Drivers/Mysqli/MysqliDriver.php
+++ b/src/Drivers/Mysqli/MysqliDriver.php
@@ -172,7 +172,7 @@ class MysqliDriver implements IDriver
 			Connection::TRANSACTION_REPEATABLE_READ => 'REPEATABLE READ',
 			Connection::TRANSACTION_SERIALIZABLE => 'SERIALIZABLE',
 		];
-		if (isset($levels[$level])) {
+		if (!isset($levels[$level])) {
 			throw new NotSupportedException("Unsupported transation level $level");
 		}
 		$this->loggedQuery("SET SESSION TRANSACTION ISOLATION LEVEL {$levels[$level]}");

--- a/src/Drivers/Pgsql/PgsqlDriver.php
+++ b/src/Drivers/Pgsql/PgsqlDriver.php
@@ -188,7 +188,7 @@ class PgsqlDriver implements IDriver
 			Connection::TRANSACTION_REPEATABLE_READ => 'REPEATABLE READ',
 			Connection::TRANSACTION_SERIALIZABLE => 'SERIALIZABLE',
 		];
-		if (isset($levels[$level])) {
+		if (!isset($levels[$level])) {
 			throw new NotSupportedException("Unsupported transation level $level");
 		}
 		$this->loggedQuery("SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL {$levels[$level]}");

--- a/src/Drivers/Sqlsrv/SqlsrvDriver.php
+++ b/src/Drivers/Sqlsrv/SqlsrvDriver.php
@@ -187,7 +187,7 @@ class SqlsrvDriver implements IDriver
 			Connection::TRANSACTION_REPEATABLE_READ => 'REPEATABLE READ',
 			Connection::TRANSACTION_SERIALIZABLE => 'SERIALIZABLE',
 		];
-		if (isset($levels[$level])) {
+		if (!isset($levels[$level])) {
 			throw new NotSupportedException("Unsupported transation level $level");
 		}
 		$this->loggedQuery("SET SESSION TRANSACTION ISOLATION LEVEL {$levels[$level]}");


### PR DESCRIPTION
For some weird reason (unknown to me) the driver method throws an exception when the transaction isolation level is known/supported except when it is not.

This pull request fixes it.