### PR TITLE
SqlProcessor: Fix regex comment

### DIFF
--- a/src/SqlProcessor.php
+++ b/src/SqlProcessor.php
@@ -120,7 +120,7 @@ class SqlProcessor
 
 			$i = $j;
 			$fragments[] = preg_replace_callback(
-				'#%((?:\.\.\.)?+\??+\w++(?:\[]){0,2}+)|(%%)|(\[\[)|(]])|\[(.+?)]#S', // %modifier | %% | %[ | %] | [identifier]
+				'#%((?:\.\.\.)?+\??+\w++(?:\[]){0,2}+)|(%%)|(\[\[)|(]])|\[(.+?)]#S', // %modifier | %% | [[ | ]] | [identifier]
 				function($matches) use ($args, &$j, $last): string {
 					if ($matches[1] !== '') {
 						if ($j === $last) {


### PR DESCRIPTION
The escaping syntax introduced in https://github.com/nextras/dbal/commit/6330fdd47ad26269d490c39287ff7502d58fe0e5 does not use percents.