### PR TITLE
Add "sslrootcert" to knownKeys in PgsqlDriver

### DIFF
--- a/src/Drivers/Pgsql/PgsqlDriver.php
+++ b/src/Drivers/Pgsql/PgsqlDriver.php
@@ -77,6 +77,7 @@ class PgsqlDriver implements IDriver
 			'connect_timeout',
 			'options',
 			'sslmode',
+			'sslrootcert',
 			'service',
 		];
 


### PR DESCRIPTION
Add key `sslrootcert` for define path to CA Root Cert, if `sslmode: verify-ca` defined.