### PR TITLE
Fix PdoMysqlDriver extendability

### DIFF
--- a/src/Drivers/PdoMysql/PdoMysqlDriver.php
+++ b/src/Drivers/PdoMysql/PdoMysqlDriver.php
@@ -59,7 +59,7 @@ use function date_default_timezone_get;
  */
 class PdoMysqlDriver extends PdoDriver
 {
-	private ?PdoMysqlResultNormalizerFactory $resultNormalizerFactory = null;
+	protected ?PdoMysqlResultNormalizerFactory $resultNormalizerFactory = null;
 
 
 	public function connect(array $params, ILogger $logger): void


### PR DESCRIPTION
For some reasons I need to extend the `PdoMysqlDriver` class and modify `connect()` method. Reasons is one project has specific requirements to PDO connection setup, I need to change how is PDO object initialized.

But the `PdoMysqlDriver` has private property `$resultNormalizerFactory` which is filled directly in `connect()` method.

This PR allows to replace `connect()` method with class childs.