### PR TITLE
add NULL ?ld handling

### DIFF
--- a/src/SqlProcessor.php
+++ b/src/SqlProcessor.php
@@ -268,6 +268,7 @@ class SqlProcessor
 					case '?b':
 					case '?dt':
 					case '?dts':
+					case '?ld':
 					case '?ldt':
 					case '?di':
 					case '?blob':

--- a/tests/cases/unit/SqlProcessorTest.scalar.phpt
+++ b/tests/cases/unit/SqlProcessorTest.scalar.phpt
@@ -200,6 +200,7 @@ class SqlProcessorScalarTest extends TestCase
 		Assert::same('NULL', $this->parser->processModifier('?f', null));
 		Assert::same('NULL', $this->parser->processModifier('?b', null));
 		Assert::same('NULL', $this->parser->processModifier('?dt', null));
+		Assert::same('NULL', $this->parser->processModifier('?ld', null));
 		Assert::same('NULL', $this->parser->processModifier('?ldt', null));
 		Assert::same('NULL', $this->parser->processModifier('?di', null));
 		Assert::same('NULL', $this->parser->processModifier('?json', null));


### PR DESCRIPTION
Probably missing `case` statement that caused exceptions (with orm) like this
![image](https://github.com/user-attachments/assets/d509a800-b18b-40f3-a1f2-d8f1ee4ff9ad)
